### PR TITLE
Add CustomAccordion component and integrate it into Home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,27 @@
 import { Button } from "@/components/ui/button";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { CustomAccordion } from "@/components/accordion/CustomAccordion";
 
 export default function Home() {
+
+  const accordionItems = [
+    {
+      value: "item-1",
+      trigger: "What is this project?",
+      content: "This is a showcase of UI components built with Next.js, Tailwind CSS and shadcn/ui."
+    },
+    {
+      value: "item-2",
+      trigger: "How are the components styled?",
+      content: "Components are styled using Tailwind CSS with a custom purple color theme."
+    },
+    {
+      value: "item-3",
+      trigger: "Can I use these components?",
+      content: "Yes, you can use and customize these components for your own projects."
+    }
+  ];
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-8 gap-8">
       {/* Buttons card */}
@@ -38,26 +58,10 @@ export default function Home() {
       {/* Accordion example */}
       <div className="bg-card shadow-lg rounded-lg p-6 w-full max-w-3xl">
         <h2 className="text-xl font-bold mb-4 text-purple-600 dark:text-purple-400">Accordion Component</h2>
-        <Accordion type="single" collapsible className="w-full">
-          <AccordionItem value="item-1">
-            <AccordionTrigger>What is this project?</AccordionTrigger>
-            <AccordionContent>
-              This is a sample project showcasing various UI components styled with Tailwind CSS.
-            </AccordionContent>
-          </AccordionItem>
-          <AccordionItem value="item-2">
-            <AccordionTrigger>How are the components styled?</AccordionTrigger>
-            <AccordionContent>
-              Components are styled using Tailwind CSS with a custom purple color theme.
-            </AccordionContent>
-          </AccordionItem>
-          <AccordionItem value="item-3">
-            <AccordionTrigger>Can I use these components?</AccordionTrigger>
-            <AccordionContent>
-              Yes, you can use and customize these components for your own projects.
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+        <CustomAccordion
+          type="single"
+          items={accordionItems}
+        />
       </div>
     </div>
   );

--- a/src/components/accordion/CustomAccordion.tsx
+++ b/src/components/accordion/CustomAccordion.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+
+interface AccordionItemProps {
+    value: string;
+    trigger: React.ReactNode;
+    content: React.ReactNode;
+}
+
+interface CustomAccordionProps {
+    items: AccordionItemProps[];
+    type?: "single" | "multiple";
+    className?: string;
+}
+
+export function CustomAccordion({ items, type = "multiple", className = "w-full" }: CustomAccordionProps) {
+    return (
+        <Accordion type={type} className={className}>
+            {items.map((item) => (
+                <AccordionItem key={item.value} value={item.value}>
+                    <AccordionTrigger>{item.trigger}</AccordionTrigger>
+                    <AccordionContent>{item.content}</AccordionContent>
+                </AccordionItem>
+            ))}
+        </Accordion>
+    );
+}


### PR DESCRIPTION
This pull request refactors the accordion component in the `Home` page by introducing a reusable `CustomAccordion` component. The changes improve code reusability and simplify the `Home` page implementation.

### Refactoring and Component Reusability:

* **Introduction of `CustomAccordion` Component**: Added a new `CustomAccordion` component in `src/components/accordion/CustomAccordion.tsx`. This component accepts a list of accordion items and renders them dynamically, supporting both "single" and "multiple" accordion types.

* **Refactored Accordion in `Home` Page**: Replaced the hardcoded `Accordion` implementation in the `Home` page with the new `CustomAccordion` component. The accordion items are now defined as a separate array (`accordionItems`) and passed as props to `CustomAccordion`. This reduces redundancy and improves maintainability. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR3-R24) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL41-R64)