### PR TITLE
feat: add DatePickerWithRange component and integrate into Home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,9 @@ import { Gender } from "@/enums/gender.enum";
 import { Combobox } from "@/components/core/combobox/combobox";
 import { DatePicker } from "@/components/core/date-picker";
 import { useState } from "react";
+import { addDays } from "date-fns";
+import { DateRange } from "react-day-picker";
+import { DatePickerWithRange } from "@/components/core/date-range-picker";
 
 export default function Home() {
   // Example data for combobox
@@ -97,6 +100,11 @@ export default function Home() {
   ];
 
   const [date, setDate] = useState<Date | undefined>(undefined);
+
+  const [rangeDate, setRangeDate] = useState<DateRange | undefined>({
+    from: new Date(2022, 0, 20),
+    to: addDays(new Date(2022, 0, 20), 20),
+  });
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-8 gap-8">
@@ -313,6 +321,7 @@ export default function Home() {
         </h2>
         <div className="flex flex-col gap-4">
           <DatePicker date={date} onSelect={setDate} />
+          <DatePickerWithRange date={rangeDate} setDate={setRangeDate} />
         </div>
       </div>
     </div>

--- a/src/components/core/date-range-picker.tsx
+++ b/src/components/core/date-range-picker.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { format } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { DateRange } from "react-day-picker";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface IDatePickerWithRangeProps {
+    className?: string;
+    date?: DateRange;
+    setDate?: React.Dispatch<React.SetStateAction<DateRange | undefined>>;
+    placeholder?: string;
+}
+
+export function DatePickerWithRange({
+    className,
+    date,
+    setDate,
+    placeholder = "Pick a date",
+}: React.HTMLAttributes<HTMLDivElement> & IDatePickerWithRangeProps) {
+    return (
+        <div className={cn("grid gap-2", className)}>
+            <Popover>
+                <PopoverTrigger asChild>
+                    <Button
+                        id="date"
+                        variant={"outline"}
+                        className={cn(
+                            "w-[300px] justify-start text-left font-normal",
+                            !date && "text-muted-foreground"
+                        )}
+                    >
+                        <CalendarIcon />
+                        {date?.from ? (
+                            date.to ? (
+                                <>
+                                    {format(date.from, "LLL dd, y")} -{" "}
+                                    {format(date.to, "LLL dd, y")}
+                                </>
+                            ) : (
+                                format(date.from, "LLL dd, y")
+                            )
+                        ) : (
+                            <span>{placeholder}</span>
+                        )}
+                    </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                        initialFocus
+                        mode="range"
+                        defaultMonth={date?.from}
+                        selected={date}
+                        onSelect={setDate}
+                        numberOfMonths={2}
+                    />
+                </PopoverContent>
+            </Popover>
+        </div>
+    );
+}


### PR DESCRIPTION
This pull request introduces a new `DatePickerWithRange` component and integrates it into the `Home` page to allow users to select a range of dates. The most important changes include adding the new component, updating the `Home` page to use it, and importing necessary dependencies.

### New Component Addition:

* [`src/components/core/date-range-picker.tsx`](diffhunk://#diff-f3d0f29c683446ad4dd11cf3105bef39271f027c745c95a911152aa468add217R1-R70): Added a new `DatePickerWithRange` component that allows users to select a date range using a popover calendar. The component supports custom placeholders and integrates with the `react-day-picker` library.

### Integration into `Home` Page:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR14-R16): Imported the `DatePickerWithRange` component and its dependencies, including `DateRange` from `react-day-picker` and `addDays` from `date-fns`.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR104-R108): Added a new state variable `rangeDate` to manage the selected date range, initialized with a default range.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR324): Integrated the `DatePickerWithRange` component into the `Home` page, allowing users to pick a date range alongside the existing single-date picker.